### PR TITLE
Allow specification of file encoding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,4 @@
+sphinx
+sphinx_rtd_theme
 lxml
 requests

--- a/pybiopax/api.py
+++ b/pybiopax/api.py
@@ -31,7 +31,7 @@ def model_from_owl_file(fname, encoding=None):
     ----------
     fname : str
         A OWL file of BioPAX content.
-    encoding : str, optional
+    encoding : Optional[str]
         The encoding type to be passed to :func:`open`.
 
     Returns

--- a/pybiopax/api.py
+++ b/pybiopax/api.py
@@ -24,20 +24,22 @@ def model_from_owl_str(owl_str):
     return BioPaxModel.from_xml(etree.fromstring(owl_str.encode('utf-8')))
 
 
-def model_from_owl_file(fname):
+def model_from_owl_file(fname, encoding=None):
     """Return a BioPAX Model from an OWL string.
 
     Parameters
     ----------
     fname : str
         A OWL file of BioPAX content.
+    encoding : str, optional
+        The encoding type to be passed to :func:`open`.
 
     Returns
     -------
     pybiopax.biopax.BioPaxModel
         A BioPAX Model deserialized from the OWL file.
     """
-    with open(fname, 'r') as fh:
+    with open(fname, 'r', encoding=encoding) as fh:
         owl_str = fh.read()
         return model_from_owl_str(owl_str)
 


### PR DESCRIPTION
A PyBEL user posted this issue https://github.com/pybel/pybel/issues/473 where they were having some problems opening a file. It seemed to be an issue with the default encoding being cp1252 (probably a Windows problem).

This PR adds a backwards-compatible change so users can specify their own encoding when opening an owl file, and should allow a fix. After it's accepted and a new PyBioPAX version is released, we should also make a change to the INDRA interface that wraps this function to allow specification of non-default file encoding.
