### PR TITLE
Implement mixin properties and aggregate names

### DIFF
--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -117,7 +117,7 @@ class Named(XReffable):
 
     @property
     def name(self):
-        return [self.standard_name] + [self.display_name] + [self._name]
+        return [self.standard_name] + [self.display_name] + self._name
 
 
 class Observable:

--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -97,6 +97,7 @@ class BioPaxObject:
 
 
 class XReffable:
+    """A mixin class to add xrefs to a BioPaxObject."""
     list_types = ['xref']
 
     def __init__(self, xref=None, **kwargs):
@@ -106,6 +107,7 @@ class XReffable:
 
 
 class Named(XReffable):
+    """A mixin class to add names to a BioPaxObject."""
     list_types = XReffable.list_types + ['name']
 
     def __init__(self, display_name=None, standard_name=None, name=None,
@@ -121,6 +123,7 @@ class Named(XReffable):
 
 
 class Observable:
+    """A mixin class to add evidence to a BioPaxObject."""
     list_types = ['evidence']
 
     def __init__(self, evidence=None, **kwargs):

--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -66,6 +66,12 @@ class BioPaxObject:
             val = getattr(self, attr)
             if val is None:
                 continue
+
+            # We have to implement special handling for names to make sure
+            # we don't serialize display/standard names here
+            if attr == 'name' and isinstance(self, Named):
+                val = self.get_plain_names()
+
             if isinstance(val, list):
                 for v in val:
                     child_elem = self._simple_to_xml(attr, v)
@@ -119,7 +125,12 @@ class Named(XReferrable):
 
     @property
     def name(self):
-        return [self.standard_name] + [self.display_name] + self._name
+        std_name = [self.standard_name] if self.standard_name else []
+        disp_name = [self.display_name] if self.display_name else []
+        return std_name + disp_name + self._name
+
+    def get_plain_names(self):
+        return self._name
 
 
 class Observable:

--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -96,7 +96,7 @@ class BioPaxObject:
         return None
 
 
-class XReffable:
+class XReferrable:
     """A mixin class to add xrefs to a BioPaxObject."""
     list_types = ['xref']
 
@@ -106,9 +106,9 @@ class XReffable:
         self.xref = xref
 
 
-class Named(XReffable):
+class Named(XReferrable):
     """A mixin class to add names to a BioPaxObject."""
-    list_types = XReffable.list_types + ['name']
+    list_types = XReferrable.list_types + ['name']
 
     def __init__(self, display_name=None, standard_name=None, name=None,
                  **kwargs):

--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -11,10 +11,12 @@ class Unresolved:
 class BioPaxObject:
     """Generic BioPAX Object. It is the parent class of all more specific
     BioPAX classes."""
-    list_types = ['xref', 'comment', 'name']
+    list_types = ['comment']
     xml_types = {}
 
-    def __init__(self, uid, comment=None):
+    def __init__(self, uid, comment=None, **kwargs):
+        # Pass on for cooperative inheritance
+        super().__init__(**kwargs)
         self.uid = uid
         self.comment = comment
 
@@ -97,7 +99,9 @@ class BioPaxObject:
 class XReffable:
     list_types = ['xref']
 
-    def __init__(self, xref=None):
+    def __init__(self, xref=None, **kwargs):
+        # Pass on for cooperative inheritance
+        super().__init__(**kwargs)
         self.xref = xref
 
 
@@ -119,7 +123,9 @@ class Named(XReffable):
 class Observable:
     list_types = ['evidence']
 
-    def __init__(self, evidence=None):
+    def __init__(self, evidence=None, **kwargs):
+        # Pass on for cooperative inheritance
+        super().__init__(**kwargs)
         self.evidence = evidence
 
 

--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -14,13 +14,9 @@ class BioPaxObject:
     list_types = ['xref', 'comment', 'name']
     xml_types = {}
 
-    def __init__(self, uid, name=None, comment=None, xref=None):
+    def __init__(self, uid, comment=None):
         self.uid = uid
-        # TODO: is name in the right place here?
-        self.name = name
         self.comment = comment
-        # TODO: is xref in the right place here?
-        self.xref = xref
 
     @classmethod
     def from_xml(cls, element):
@@ -98,28 +94,49 @@ class BioPaxObject:
         return None
 
 
-class Entity(BioPaxObject):
+class XReffable:
+    list_types = ['xref']
+
+    def __init__(self, xref=None):
+        self.xref = xref
+
+
+class Named(XReffable):
+    list_types = XReffable.list_types + ['name']
+
+    def __init__(self, display_name=None, standard_name=None, name=None,
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.display_name = display_name
+        self.standard_name = standard_name
+        self._name = name
+
+    @property
+    def name(self):
+        return [self.standard_name] + [self.display_name] + [self._name]
+
+
+class Observable:
+    list_types = ['evidence']
+
+    def __init__(self, evidence=None):
+        self.evidence = evidence
+
+
+class Entity(BioPaxObject, Observable, Named):
     """BioPAX Entity."""
-    list_types = BioPaxObject.list_types + \
-        ['evidence', 'data_source']
+    list_types = BioPaxObject.list_types + Observable.list_types + \
+        Named.list_types + ['data_source']
 
     def __init__(self,
-                 standard_name=None,
-                 display_name=None,
-                 all_names=None,
                  participant_of=None,
                  availability=None,
                  data_source=None,
-                 evidence=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.standard_name = standard_name
-        self.display_name = display_name
-        self.all_names = all_names
         self.participant_of = participant_of
         self.availability = availability
         self.data_source = data_source
-        self.evidence = evidence
 
 
 class Gene(Entity):

--- a/pybiopax/biopax/model.py
+++ b/pybiopax/biopax/model.py
@@ -54,7 +54,10 @@ class BioPaxModel:
                     objects[sub_obj.uid] = sub_obj
 
         for obj_id, obj in objects.items():
-            for attr in [a for a in dir(obj) if not a.startswith('__')]:
+            for attr in [a for a in dir(obj) if not a.startswith('_')]:
+                # This is to avoid properties
+                if attr not in obj.__dict__:
+                    continue
                 val = getattr(obj, attr)
                 resolved_val = resolve_value(objects, val)
                 setattr(obj, attr, resolved_val)

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -41,9 +41,9 @@ class Evidence(UtilityClass, XReffable):
         self.experimental_form = experimental_form
 
 
-class Provenance(UtilityClass, XReffable, Named):
+class Provenance(UtilityClass, Named):
     """BioPAX Provenance."""
-    list_types = XReffable.list_types + Named.list_types
+    list_types = Named.list_types
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -17,7 +17,7 @@ __all__ = ['UtilityClass', 'Evidence', 'Provenance',
            'SequenceRegionVocabulary', 'TissueVocabulary', 'CellVocabulary',
            'Score']
 
-from .base import BioPaxObject, Named, Observable, XReffable
+from .base import BioPaxObject, Named, Observable, XReferrable
 
 
 class UtilityClass(BioPaxObject):
@@ -26,8 +26,8 @@ class UtilityClass(BioPaxObject):
         super().__init__(**kwargs)
 
 
-class Evidence(UtilityClass, XReffable):
-    list_types = UtilityClass.list_types + XReffable.list_types
+class Evidence(UtilityClass, XReferrable):
+    list_types = UtilityClass.list_types + XReferrable.list_types
 
     """BioPAX Evidence."""
     def __init__(self,
@@ -307,8 +307,8 @@ class RelationshipXref(Xref):
         self.relationship_type = relationship_type
 
 
-class Score(UtilityClass, XReffable):
-    list_types = XReffable.list_types
+class Score(UtilityClass, XReferrable):
+    list_types = XReferrable.list_types
 
     """BioPAX Score."""
     def __init__(self,
@@ -415,9 +415,9 @@ class Stoichiometry(UtilityClass):
         self.physical_entity = physical_entity
 
 
-class ControlledVocabulary(UtilityClass, XReffable):
+class ControlledVocabulary(UtilityClass, XReferrable):
     """BioPAX ControlledVocabulary."""
-    list_types = UtilityClass.list_types + XReffable.list_types + ['term']
+    list_types = UtilityClass.list_types + XReferrable.list_types + ['term']
 
     def __init__(self, term=None, **kwargs):
         super().__init__(**kwargs)

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -17,7 +17,7 @@ __all__ = ['UtilityClass', 'Evidence', 'Provenance',
            'SequenceRegionVocabulary', 'TissueVocabulary', 'CellVocabulary',
            'Score']
 
-from .base import BioPaxObject
+from .base import BioPaxObject, Named, Observable, XReffable
 
 
 class UtilityClass(BioPaxObject):
@@ -26,7 +26,9 @@ class UtilityClass(BioPaxObject):
         super().__init__(**kwargs)
 
 
-class Evidence(UtilityClass):
+class Evidence(UtilityClass, XReffable):
+    list_types = UtilityClass.list_types + XReffable.list_types
+
     """BioPAX Evidence."""
     def __init__(self,
                  confidence=None,
@@ -39,25 +41,19 @@ class Evidence(UtilityClass):
         self.experimental_form = experimental_form
 
 
-class Provenance(UtilityClass):
+class Provenance(UtilityClass, XReffable, Named):
     """BioPAX Provenance."""
-    def __init__(self,
-                 standard_name=None,
-                 display_name=None,
-                 all_names=None,
-                 **kwargs):
+    list_types = XReffable.list_types + Named.list_types
+
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.standard_name = standard_name
-        self.display_name = display_name
-        self.all_names = all_names
 
 
-class EntityFeature(UtilityClass):
+class EntityFeature(UtilityClass, Observable):
     """BioPAX UtilityClass."""
-    list_types = UtilityClass.list_types + ['evidence']
+    list_types = UtilityClass.list_types + Observable.list_types
 
     def __init__(self,
-                 evidence=None,
                  owner_entity_reference=None,
                  feature_of=None,
                  not_feature_of=None,
@@ -67,7 +63,6 @@ class EntityFeature(UtilityClass):
                  member_feature_of=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.evidence = evidence
         self.owner_entity_reference = owner_entity_reference
         self.feature_of = feature_of
         self.not_feature_of = not_feature_of
@@ -158,22 +153,18 @@ class ChemicalStructure(UtilityClass):
         self.structure_data = structure_data
 
 
-class BioSource(UtilityClass):
+class BioSource(UtilityClass, Named):
     """BioPAX BioSource."""
+    list_types = Named.list_types
+
     def __init__(self,
                  cell_type=None,
                  tissue=None,
-                 standard_name=None,
-                 display_name=None,
-                 all_names=None,
                  taxon_xref=None,
                  **kwargs):
         super().__init__(**kwargs)
         self.cell_type = cell_type
         self.tissue = tissue
-        self.standard_name = standard_name
-        self.display_name = display_name
-        self.all_names = all_names
         self.taxon_xref = taxon_xref
 
 
@@ -238,23 +229,21 @@ class SequenceSite(SequenceLocation):
         return str(self)
 
 
-class PathwayStep(UtilityClass):
+class PathwayStep(UtilityClass, Observable):
     """BioPAX PathwayStep."""
-    list_types = UtilityClass.list_types + ['evidence']
+    list_types = UtilityClass.list_types + Observable.list_types
 
     def __init__(self,
                  step_process=None,
                  next_step=None,
                  next_step_of=None,
                  pathway_order_of=None,
-                 evidence=None,
                  **kwargs):
         super().__init__(**kwargs)
         self.step_process = step_process
         self.next_step = next_step
         self.next_step_of = next_step_of
         self.pathway_order_of = pathway_order_of
-        self.evidence = evidence
 
 
 class BiochemicalPathwayStep(PathwayStep):
@@ -318,7 +307,9 @@ class RelationshipXref(Xref):
         self.relationship_type = relationship_type
 
 
-class Score(UtilityClass):
+class Score(UtilityClass, XReffable):
+    list_types = XReffable.list_types
+
     """BioPAX Score."""
     def __init__(self,
                  score_source=None,
@@ -329,35 +320,24 @@ class Score(UtilityClass):
         self.value = value
 
 
-class EntityReference(UtilityClass):
+class EntityReference(UtilityClass, Named, Observable):
     """BioPAX EntityReference."""
-    list_types = UtilityClass.list_types + \
-        ['evidence', 'entity_feature', 'member_entity_reference']
+    list_types = UtilityClass.list_types + Named.list_types + \
+        Observable.list_types + ['entity_feature', 'member_entity_reference']
 
     def __init__(self,
                  entity_feature=None,
                  entity_reference_of=None,
-                 evidence=None,
                  entity_reference_type=None,
                  member_entity_reference=None,
                  owner_entity_reference=None,
-                 xref=None,
-                 standard_name=None,
-                 display_name=None,
-                 all_names=None,
                  **kwargs):
         super().__init__(**kwargs)
         self.entity_feature = entity_feature
         self.entity_reference_of = entity_reference_of
-        self.evidence = evidence
         self.entity_reference_type = entity_reference_type
         self.member_entity_reference = member_entity_reference
         self.owner_entity_reference = owner_entity_reference
-        # TODO: is xref in the right location here?
-        self.xref = xref
-        self.standard_name = standard_name
-        self.display_name = display_name
-        self.all_names = all_names
 
 
 class SequenceEntityReference(EntityReference):
@@ -435,9 +415,9 @@ class Stoichiometry(UtilityClass):
         self.physical_entity = physical_entity
 
 
-class ControlledVocabulary(UtilityClass):
+class ControlledVocabulary(UtilityClass, XReffable):
     """BioPAX ControlledVocabulary."""
-    list_types = UtilityClass.list_types + ['term']
+    list_types = UtilityClass.list_types + XReffable.list_types + ['term']
 
     def __init__(self, term=None, **kwargs):
         super().__init__(**kwargs)

--- a/pybiopax/tests/test_biopax.py
+++ b/pybiopax/tests/test_biopax.py
@@ -36,7 +36,9 @@ def test_process_molecular_interactions():
         model.objects['MolecularInteraction_1e82d9951c7d71c02ee6e7bdc7cb8e47']
     assert isinstance(mol_int.participant, list)
     assert len(mol_int.participant) == 2
-    names = {part.display_name for part in mol_int.participant}
+    disp_names = {part.display_name for part in mol_int.participant}
+    assert disp_names == {'ALG6', 'ALG8'}
+    names = {part.name for part in mol_int.participants}
     assert names == {'ALG6', 'ALG8'}
 
     # Smoke test serialization

--- a/pybiopax/tests/test_biopax.py
+++ b/pybiopax/tests/test_biopax.py
@@ -38,8 +38,9 @@ def test_process_molecular_interactions():
     assert len(mol_int.participant) == 2
     disp_names = {part.display_name for part in mol_int.participant}
     assert disp_names == {'ALG6', 'ALG8'}
-    names = {part.name for part in mol_int.participants}
-    assert names == {'ALG6', 'ALG8'}
+    names = set.union(*[set(part.name) for part in mol_int.participant])
+    assert names == {'ALG8', 'CDG1H', 'CDG1C', 'ALG6, CDG1C', 'ALG6',
+                     'ALG8, CDG1H, MGC2840'}, names
 
     # Smoke test serialization
     model_to_owl_file(model, 'test_output.owl')


### PR DESCRIPTION
This PR implements the `Named`, `Observable` and `XReferrable` mixin classes to allow adding certain properties to only some BioPaxObjects (in a manner similar to the Paxtools implementation in Java) and avoiding having to define these properties in BioPaxObject directly, or duplicating these in low-level classes. This makes it possible to handle the complicated logic behind names in a single place.