### PR TITLE
Implement reverse links as properties

### DIFF
--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -1,4 +1,5 @@
-__all__ = ['BioPaxObject', 'Entity', 'Pathway', 'Gene', 'Unresolved']
+__all__ = ['BioPaxObject','Controller', 'Entity', 'Pathway', 'Gene',
+           'Unresolved']
 
 from ..xml_util import *
 
@@ -149,14 +150,17 @@ class Entity(BioPaxObject, Observable, Named):
         Named.list_types + ['data_source']
 
     def __init__(self,
-                 participant_of=None,
                  availability=None,
                  data_source=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.participant_of = participant_of
         self.availability = availability
         self.data_source = data_source
+        self._participant_of = set()
+
+    @property
+    def participant_of(self):
+        return self._participant_of
 
 
 class Gene(Entity):

--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -166,7 +166,18 @@ class Gene(Entity):
         self.organism = organism
 
 
-class Pathway(Entity):
+class Controller:
+    """BioPAX Controller."""
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._controller_of = set()
+
+    @property
+    def controller_of(self):
+        return self.controller_of
+
+
+class Pathway(Entity, Controller):
     """BioPAX Pathway."""
     list_types = Entity.list_types + ['pathway_component']
 

--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -178,7 +178,7 @@ class Controller:
 
     @property
     def controller_of(self):
-        return self.controller_of
+        return self._controller_of
 
 
 class Pathway(Entity, Controller):

--- a/pybiopax/biopax/interaction.py
+++ b/pybiopax/biopax/interaction.py
@@ -11,14 +11,23 @@ from .base import Entity
 class Process(Entity):
     """BioPAX Process."""
     def __init__(self,
-                 controlled_of=None,
-                 step_process_of=None,
-                 pathway_component_of=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.controlled_of = controlled_of
-        self.step_process_of = step_process_of
-        self.pathway_component_of = pathway_component_of
+        self._controlled_of = set()
+        self._step_process_of = set()
+        self._pathway_component_of = set()
+
+    @property
+    def controlled_of(self):
+        return self._controlled_of
+
+    @property
+    def step_process_of(self):
+        return self._step_process_of
+
+    @property
+    def pathway_component_of(self):
+        return self._pathway_component_of
 
 
 class Interaction(Process):

--- a/pybiopax/biopax/model.py
+++ b/pybiopax/biopax/model.py
@@ -76,6 +76,25 @@ class BioPaxModel:
             if isinstance(obj, obj_type):
                 yield obj
 
+    def add_reverse_links(self):
+        for uid, obj in self.objects.items():
+            for attr in [a for a in dir(obj) if not a.startswith('_')
+                         and a not in {'list_types', 'xml_types',
+                                       'to_xml', 'from_xml', 'uid'}]:
+                val = getattr(obj, attr)
+                if isinstance(val, BioPaxObject) or \
+                        (isinstance(val, list) and
+                         all(isinstance(v, BioPaxObject) for v in val)):
+                    if attr in ['left', 'right']:
+                        of_attr = '_participant_of'
+                    else:
+                        of_attr = '_%s_of' % attr
+                    vals = val if isinstance(val, list) else [val]
+                    for v in vals:
+                        if of_attr in dir(v):
+                            of_attr_val = getattr(v, of_attr)
+                            of_attr_val.add(obj)
+
 
 def get_sub_objects(obj):
     """Get all the children of an object that were extracted and

--- a/pybiopax/biopax/model.py
+++ b/pybiopax/biopax/model.py
@@ -30,6 +30,7 @@ class BioPaxModel:
     def __init__(self, objects, xml_base):
         self.objects = objects
         self.xml_base = xml_base
+        self.add_reverse_links()
 
     @classmethod
     def from_xml(cls, tree, tqdm_kwargs: Optional[Mapping[str, Any]] = None):

--- a/pybiopax/biopax/physical_entity.py
+++ b/pybiopax/biopax/physical_entity.py
@@ -21,6 +21,16 @@ class PhysicalEntity(Entity, Controller):
         self.not_feature = not_feature
         self.member_physical_entity = member_physical_entity
         self.cellular_location = cellular_location
+        self._component_of = set()
+        self._member_physical_entity_of = set()
+
+    @property
+    def component_of(self):
+        return self._component_of
+
+    @property
+    def member_physical_entity_of(self):
+        return self._member_physical_entity_of
 
     def __str__(self):
         name = self.display_name if self.display_name else self.standard_name

--- a/pybiopax/biopax/physical_entity.py
+++ b/pybiopax/biopax/physical_entity.py
@@ -2,10 +2,10 @@ __all__ = ['PhysicalEntity', 'SimplePhysicalEntity', 'Protein',
            'SmallMolecule', 'Rna', 'Complex', 'Dna', 'DnaRegion',
            'RnaRegion']
 
-from .base import Entity
+from .base import Entity, Controller
 
 
-class PhysicalEntity(Entity):
+class PhysicalEntity(Entity, Controller):
     """BioPAX PhysicalEntity."""
     list_types = Entity.list_types + \
         ['feature', 'not_feature', 'member_physical_entity']
@@ -13,18 +13,12 @@ class PhysicalEntity(Entity):
     def __init__(self,
                  feature=None,
                  not_feature=None,
-                 controller_of=None,
-                 component_of=None,
-                 member_physical_entity_of=None,
                  member_physical_entity=None,
                  cellular_location=None,
                  **kwargs):
         super().__init__(**kwargs)
         self.feature = feature
         self.not_feature = not_feature
-        self.controller_of = controller_of
-        self.component_of = component_of
-        self.member_physical_entity_of = member_physical_entity_of
         self.member_physical_entity = member_physical_entity
         self.cellular_location = cellular_location
 

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -264,14 +264,17 @@ class Xref(UtilityClass):
                  id=None,
                  db_version=None,
                  id_version=None,
-                 xref_of=None,
                  **kwargs):
         super().__init__(**kwargs)
         self.db = db
         self.db_version = db_version
         self.id_version = id_version
         self.id = id
-        self.xref_of = xref_of
+        self._xref_of = set()
+
+    @property
+    def xref_of(self):
+        return self._xref_of
 
 
 class PublicationXref(Xref):

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -263,7 +263,7 @@ class PathwayStep(UtilityClass, Observable):
 
     @property
     def pathway_order_of(self):
-        return self.pathway_order_of
+        return self._pathway_order_of
 
 
 class BiochemicalPathwayStep(PathwayStep):

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -55,21 +55,35 @@ class EntityFeature(UtilityClass, Observable):
 
     def __init__(self,
                  owner_entity_reference=None,
-                 feature_of=None,
-                 not_feature_of=None,
                  feature_location=None,
                  member_feature=None,
                  feature_location_type=None,
-                 member_feature_of=None,
                  **kwargs):
         super().__init__(**kwargs)
         self.owner_entity_reference = owner_entity_reference
-        self.feature_of = feature_of
-        self.not_feature_of = not_feature_of
         self.feature_location = feature_location
         self.member_feature = member_feature
         self.feature_location_type = feature_location_type
-        self.member_feature_of = member_feature_of
+        self._feature_of = set()
+        self._not_feature_of = set()
+        self._entity_feature_of = set()
+        self._member_feature_of = set()
+
+    @property
+    def feature_of(self):
+        return self._feature_of
+
+    @property
+    def not_feature_of(self):
+        return self._not_feature_of
+
+    @property
+    def entity_feature_of(self):
+        return self._entity_feature_of
+
+    @property
+    def member_feature_of(self):
+        return self._member_feature_of
 
 
 class ModificationFeature(EntityFeature):
@@ -330,17 +344,25 @@ class EntityReference(UtilityClass, Named, Observable):
 
     def __init__(self,
                  entity_feature=None,
-                 entity_reference_of=None,
                  entity_reference_type=None,
                  member_entity_reference=None,
                  owner_entity_reference=None,
                  **kwargs):
         super().__init__(**kwargs)
         self.entity_feature = entity_feature
-        self.entity_reference_of = entity_reference_of
         self.entity_reference_type = entity_reference_type
         self.member_entity_reference = member_entity_reference
         self.owner_entity_reference = owner_entity_reference
+        self._entity_reference_of = set()
+        self._member_entity_reference_of = set()
+
+    @property
+    def entity_reference_of(self):
+        return self._entity_reference_of
+
+    @property
+    def member_entity_reference_of(self):
+        return self._member_entity_reference_of
 
 
 class SequenceEntityReference(EntityReference):

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -376,12 +376,22 @@ class SequenceEntityReference(EntityReference):
         self.sequence = sequence
 
 
-class RnaReference(SequenceEntityReference):
+class NucleicAcidReference(SequenceEntityReference):
+    """BioPAX NucleicAcidReference"""
+    pass
+
+
+class NucleicAcidRegionReference(NucleicAcidReference):
+    """BioPAX NucleicAcidRegionReference"""
+    pass
+
+
+class RnaReference(NucleicAcidReference):
     """BioPAX RnaReference."""
     pass
 
 
-class RnaRegionReference(EntityReference):
+class RnaRegionReference(NucleicAcidRegionReference):
     """BioPAX RnaRegionReference."""
     pass
 
@@ -406,12 +416,12 @@ class SmallMoleculeReference(EntityReference):
         self.molecular_weight = molecular_weight
 
 
-class DnaReference(SequenceEntityReference):
+class DnaReference(NucleicAcidReference):
     """BioPAX DnaReference."""
     pass
 
 
-class DnaRegionReference(EntityReference):
+class DnaRegionReference(NucleicAcidRegionReference):
     """BioPAX DnaRegionReference."""
     pass
 

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -250,14 +250,20 @@ class PathwayStep(UtilityClass, Observable):
     def __init__(self,
                  step_process=None,
                  next_step=None,
-                 next_step_of=None,
-                 pathway_order_of=None,
                  **kwargs):
         super().__init__(**kwargs)
         self.step_process = step_process
         self.next_step = next_step
-        self.next_step_of = next_step_of
-        self.pathway_order_of = pathway_order_of
+        self._next_step_of = set()
+        self._pathway_order_of = set()
+
+    @property
+    def next_step_of(self):
+        return self._next_step_of
+
+    @property
+    def pathway_order_of(self):
+        return self.pathway_order_of
 
 
 class BiochemicalPathwayStep(PathwayStep):
@@ -383,7 +389,13 @@ class NucleicAcidReference(SequenceEntityReference):
 
 class NucleicAcidRegionReference(NucleicAcidReference):
     """BioPAX NucleicAcidRegionReference"""
-    pass
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._subregion_of = set()
+
+    @property
+    def subregion_of(self):
+        return self._subregion_of
 
 
 class RnaReference(NucleicAcidReference):


### PR DESCRIPTION
This PR implements all reverse object references (e.g., `xref_of`) as properties which refer to hidden attributes. Reverse links are added at the BioPAX Model level upon instantiation.