### PR TITLE
Implement path search based on path string specification

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,6 +12,7 @@ PyBioPAX documentation
    modules/api
    modules/biopax
    modules/pc_client
+   modules/paths
    modules/xml_util
 
 

--- a/doc/modules/paths.rst
+++ b/doc/modules/paths.rst
@@ -1,0 +1,6 @@
+Path finding
+============
+
+.. automodule:: pybiopax.paths
+    :members:
+    :show-inheritance:

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -75,8 +75,6 @@ def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
         # At this point, val is guaranteed to be a list of BioPaxObjects
         results = []
         for v in val:
-            if not isinstance(v, BioPaxObject):
-                continue
             if cls and not isinstance(v, cls):
                 continue
             if not last:

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -81,10 +81,10 @@ def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
         if cls and not isinstance(v, cls):
             continue
         if rest:
-            results.append(find_objects(v, rest))
+            results += find_objects(v, rest)
         else:
-            results.append([v])
-    return list(itertools.chain(*results))
+            results.append(v)
+    return results
 
 
 def _get_object_list(val):

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -24,6 +24,8 @@ def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
         separated by /. Each part is the name of an object attribute, and
         can optionally contain a class name as well, separated by : to
         constrain the class of the target of the attribute to consider.
+        Optionally, each attribute can also have a * suffix to make the
+        search recursive.
 
     Returns
     -------

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -1,0 +1,23 @@
+from .biopax import BioPaxObject
+
+
+def find_objects(start_obj: BioPaxObject, path_str: str):
+    parts = path_str.split('/')
+    last = True if len(parts) == 1 else False
+    for part in parts:
+        if ':' in part:
+            attribute, class_constraint = part.split(':', maxsplit=1)
+        else:
+            attribute, class_constraint = part, None
+        val = getattr(start_obj, attribute, None)
+        if val is None:
+            return []
+        elif isinstance(val, BioPaxObject):
+            if not last:
+                return find_objects(val, '/'.join(parts[1:]))
+            else:
+                return [val]
+        elif isinstance(val, list):
+            results = []
+            for v in val:
+                results.append(find_objects(v, '/'.join(parts[1:])))

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -1,6 +1,7 @@
 __all__ = ['find_objects', 'BiopaxClassConstraintError']
 
 import logging
+import itertools
 from .biopax import *
 
 
@@ -40,8 +41,8 @@ def find_objects(start_obj: BioPaxObject, path_str: str):
                 if not last:
                     results.append(find_objects(v, '/'.join(parts[1:])))
                 else:
-                    results.append(v)
-            return results
+                    results.append([v])
+            return list(itertools.chain(*results))
 
 
 def _make_biopax_cls_map():

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -20,4 +20,8 @@ def find_objects(start_obj: BioPaxObject, path_str: str):
         elif isinstance(val, list):
             results = []
             for v in val:
-                results.append(find_objects(v, '/'.join(parts[1:])))
+                if not last:
+                    results.append(find_objects(v, '/'.join(parts[1:])))
+                else:
+                    results.append(v)
+            return results

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -3,7 +3,6 @@ given object using a path constraint string."""
 __all__ = ['find_objects', 'BiopaxClassConstraintError']
 
 import logging
-import itertools
 from typing import List
 from .biopax import *
 
@@ -42,9 +41,7 @@ def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
         try:
             cls = biopax_cls_map[class_constraint_str]
         except KeyError:
-            raise BiopaxClassConstraintError(f'{class_constraint_str} '
-                                             f'is not a valid BioPax class '
-                                             f'name.') from None
+            raise BiopaxClassConstraintError(class_constraint_str) from None
     else:
         attribute, cls = part, None
 
@@ -107,4 +104,8 @@ biopax_cls_map = _make_biopax_cls_map()
 
 
 class BiopaxClassConstraintError(KeyError):
-    pass
+    def __init__(self, cls_str):
+        self.cls_str = cls_str
+
+    def __str__(self):
+        return f'{self.cls_str} is not a valid BioPAX class name.'

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -1,14 +1,35 @@
+"""This module implements finding paths in a BioPaxModel starting from a
+given object using a path constraint string."""
 __all__ = ['find_objects', 'BiopaxClassConstraintError']
 
 import logging
 import itertools
+from typing import List
 from .biopax import *
 
 
 logger = logging.getLogger(__name__)
 
 
-def find_objects(start_obj: BioPaxObject, path_str: str):
+def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
+    """Return objects matching the given path specification.
+
+    Parameters
+    ----------
+    start_obj :
+        The object to start the search from.
+
+    path_str :
+        A path specification string which consists of one or more parts
+        separated by /. Each part is the name of an object attribute, and
+        can optionally contain a class name as well, separated by : to
+        constrain the class of the target of the attribute to consider.
+
+    Returns
+    -------
+    :
+        A list of BioPaxObjects satisfying the given path specification.
+    """
     parts = path_str.split('/')
     last = True if len(parts) == 1 else False
     for part in parts:
@@ -55,5 +76,5 @@ def _make_biopax_cls_map():
 biopax_cls_map = _make_biopax_cls_map()
 
 
-class BiopaxClassConstraintError(KeyError):
+class BiopaxClassConstraintError(Exception):
     pass

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -52,6 +52,7 @@ def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
 
         # Get the attribute we are looking for
         attr_val = getattr(start_obj, attribute, None)
+        # We turn the value into a flat list of BioPaxObjects
         val = _get_object_list(attr_val)
 
         # If this is a recursive part, we run a BFS to get all the downstream
@@ -69,31 +70,18 @@ def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
                         queue.append(child)
             val = visited
 
-        # If it's a single object
-        if isinstance(val, BioPaxObject):
-            if cls and not isinstance(val, cls):
-                return []
+        # At this point, val is guaranteed to be a list of BioPaxObjects
+        results = []
+        for v in val:
+            if not isinstance(v, BioPaxObject):
+                continue
+            if cls and not isinstance(v, cls):
+                continue
             if not last:
-                return find_objects(val, '/'.join(parts[1:]))
+                results.append(find_objects(v, '/'.join(parts[1:])))
             else:
-                return [val]
-        # If it's a list of objects
-        elif isinstance(val, list):
-            results = []
-            for v in val:
-                if not isinstance(v, BioPaxObject):
-                    continue
-                if cls and not isinstance(v, cls):
-                    continue
-                if not last:
-                    results.append(find_objects(v, '/'.join(parts[1:])))
-                else:
-                    results.append([v])
-            return list(itertools.chain(*results))
-        # Otherwise it's a value other than a BioPaxObject which we don't
-        # consider here
-        else:
-            return []
+                results.append([v])
+        return list(itertools.chain(*results))
 
 
 def _get_object_list(val):

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -32,56 +32,59 @@ def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
     :
         A list of BioPaxObjects satisfying the given path specification.
     """
-    parts = path_str.split('/')
-    last = True if len(parts) == 1 else False
-    for part in parts:
-        if ':' in part:
-            attribute, class_constraint_str = part.split(':', maxsplit=1)
-            try:
-                cls = biopax_cls_map[class_constraint_str]
-            except KeyError:
-                raise BiopaxClassConstraintError(f'{class_constraint_str} '
-                                                 f'is not a valid BioPax class '
-                                                 f'name.') from None
+    # We split off the first part and separate out the rest
+    part, rest = path_str.split('/', maxsplit=1) \
+        if '/' in path_str else (path_str, None)
+
+    # Handle class constraint
+    if ':' in part:
+        attribute, class_constraint_str = part.split(':', maxsplit=1)
+        try:
+            cls = biopax_cls_map[class_constraint_str]
+        except KeyError:
+            raise BiopaxClassConstraintError(f'{class_constraint_str} '
+                                             f'is not a valid BioPax class '
+                                             f'name.') from None
+    else:
+        attribute, cls = part, None
+
+    # Handle recursion marker
+    if attribute.endswith('*'):
+        attribute = attribute[:-1]
+        recursive = True
+    else:
+        recursive = False
+
+    # Get the attribute we are looking for
+    attr_val = getattr(start_obj, attribute, None)
+    # We turn the value into a flat list of BioPaxObjects
+    val = _get_object_list(attr_val)
+
+    # If this is a recursive part, we run a BFS to get all the downstream
+    # objects that can be reached via one or more of the given type of
+    # attribute links
+    if recursive:
+        queue = val[:]
+        visited = val[:]
+        while queue:
+            obj = queue.pop(0)
+            obj_val = getattr(obj, attribute, None)
+            for child in _get_object_list(obj_val):
+                if child not in visited:
+                    visited.append(child)
+                    queue.append(child)
+        val = visited
+
+    # At this point, val is guaranteed to be a list of BioPaxObjects
+    results = []
+    for v in val:
+        if cls and not isinstance(v, cls):
+            continue
+        if rest:
+            results.append(find_objects(v, rest))
         else:
-            attribute, cls = part, None
-
-        if attribute.endswith('*'):
-            attribute = attribute[:-1]
-            recursive = True
-        else:
-            recursive = False
-
-        # Get the attribute we are looking for
-        attr_val = getattr(start_obj, attribute, None)
-        # We turn the value into a flat list of BioPaxObjects
-        val = _get_object_list(attr_val)
-
-        # If this is a recursive part, we run a BFS to get all the downstream
-        # objects that can be reached via one or more of the given type of
-        # attribute links
-        if recursive:
-            queue = val[:]
-            visited = val[:]
-            while queue:
-                obj = queue.pop(0)
-                obj_val = getattr(obj, attribute, None)
-                for child in _get_object_list(obj_val):
-                    if child not in visited:
-                        visited.append(child)
-                        queue.append(child)
-            val = visited
-
-        # At this point, val is guaranteed to be a list of BioPaxObjects
-        results = []
-        for v in val:
-            if cls and not isinstance(v, cls):
-                continue
-            if not last:
-                results.append(find_objects(v, '/'.join(parts[1:])))
-            else:
-                results.append([v])
-        return list(itertools.chain(*results))
+            results.append([v])
+    return list(itertools.chain(*results))
 
 
 def _get_object_list(val):

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -1,4 +1,10 @@
-from .biopax import BioPaxObject
+__all__ = ['find_objects', 'BiopaxClassConstraintError']
+
+import logging
+from .biopax import *
+
+
+logger = logging.getLogger(__name__)
 
 
 def find_objects(start_obj: BioPaxObject, path_str: str):
@@ -6,13 +12,22 @@ def find_objects(start_obj: BioPaxObject, path_str: str):
     last = True if len(parts) == 1 else False
     for part in parts:
         if ':' in part:
-            attribute, class_constraint = part.split(':', maxsplit=1)
+            attribute, class_constraint_str = part.split(':', maxsplit=1)
+            try:
+                cls = biopax_cls_map[class_constraint_str]
+            except KeyError as e:
+                raise BiopaxClassConstraintError(f'{class_constraint_str} '
+                                                 f'is not a valid BioPax class '
+                                                 f'name.')
         else:
-            attribute, class_constraint = part, None
+            attribute, cls = part, None
+
         val = getattr(start_obj, attribute, None)
         if val is None:
             return []
         elif isinstance(val, BioPaxObject):
+            if cls and not isinstance(val, cls):
+                return []
             if not last:
                 return find_objects(val, '/'.join(parts[1:]))
             else:
@@ -20,8 +35,24 @@ def find_objects(start_obj: BioPaxObject, path_str: str):
         elif isinstance(val, list):
             results = []
             for v in val:
+                if cls and not isinstance(v, cls):
+                    continue
                 if not last:
                     results.append(find_objects(v, '/'.join(parts[1:])))
                 else:
                     results.append(v)
             return results
+
+
+def _make_biopax_cls_map():
+    import inspect
+    from pybiopax import biopax
+    return {k: v for k, v in inspect.getmembers(biopax, inspect.isclass)
+            if issubclass(v, BioPaxObject)}
+
+
+biopax_cls_map = _make_biopax_cls_map()
+
+
+class BiopaxClassConstraintError(KeyError):
+    pass

--- a/pybiopax/paths.py
+++ b/pybiopax/paths.py
@@ -39,10 +39,10 @@ def find_objects(start_obj: BioPaxObject, path_str: str) -> List[BioPaxObject]:
             attribute, class_constraint_str = part.split(':', maxsplit=1)
             try:
                 cls = biopax_cls_map[class_constraint_str]
-            except KeyError as e:
+            except KeyError:
                 raise BiopaxClassConstraintError(f'{class_constraint_str} '
                                                  f'is not a valid BioPax class '
-                                                 f'name.')
+                                                 f'name.') from None
         else:
             attribute, cls = part, None
 
@@ -103,5 +103,5 @@ def _make_biopax_cls_map():
 biopax_cls_map = _make_biopax_cls_map()
 
 
-class BiopaxClassConstraintError(Exception):
+class BiopaxClassConstraintError(KeyError):
     pass

--- a/pybiopax/tests/test_biopax.py
+++ b/pybiopax/tests/test_biopax.py
@@ -57,7 +57,7 @@ def test_get_netpath():
 def test_get_reactome():
     m = pybiopax.model_from_reactome("177929")
     assert isinstance(m, BioPaxModel)
-    assert m.xml_base == "http://www.reactome.org/biopax/77/177929#"
+    assert m.xml_base == "http://www.reactome.org/biopax/78/177929#"
     assert 0 < len(m.objects)
 
 

--- a/pybiopax/tests/test_paths.py
+++ b/pybiopax/tests/test_paths.py
@@ -1,3 +1,4 @@
+import pytest
 from pybiopax.biopax import *
 from pybiopax.paths import find_objects, BiopaxClassConstraintError
 
@@ -45,3 +46,13 @@ def test_find_objects_constraints():
     objects = find_objects(protref, 'xref:UnificationXref/xref_of')
     assert len(objects) == 1
     assert objects[0] == protref, objects
+
+    objects = find_objects(protref, 'xref:UnificationXref/xref_of:RnaReference')
+    assert not objects
+
+
+def test__with_invalid_class():
+    xr1 = UnificationXref(uid='1')
+
+    with pytest.raises(BiopaxClassConstraintError):
+        find_objects(xr1, 'xref_of:XXX')

--- a/pybiopax/tests/test_paths.py
+++ b/pybiopax/tests/test_paths.py
@@ -1,0 +1,11 @@
+from pybiopax.biopax import *
+from pybiopax.paths import find_objects
+
+
+def test_find_objects():
+    protref = EntityReference(uid='1')
+    prot = Protein(uid='2', standard_name='x', entity_reference=protref)
+    protref._entity_reference_of = [prot]
+    objects = find_objects(prot, 'entity_reference')
+    assert len(objects) == 1, objects
+    assert objects[0] == protref

--- a/pybiopax/tests/test_paths.py
+++ b/pybiopax/tests/test_paths.py
@@ -1,5 +1,5 @@
 from pybiopax.biopax import *
-from pybiopax.paths import find_objects
+from pybiopax.paths import find_objects, BiopaxClassConstraintError
 
 
 def test_find_objects():
@@ -21,3 +21,27 @@ def test_find_objects():
     objects = find_objects(prot, 'entity_reference/entity_reference_of')
     assert len(objects) == 1, objects
     assert objects[0] == prot, objects
+
+
+def test_find_objects_constraints():
+    xr1 = UnificationXref(uid='2')
+    xr2 = PublicationXref(uid='3')
+    xr3 = RelationshipXref(uid='4')
+    protref = EntityReference(uid='1', xref=[xr1, xr2, xr3])
+    xr1._xref_of = [protref]
+    xr2._xref_of = [protref]
+    xr3._xref_of = [protref]
+
+    objects = find_objects(protref, 'xref')
+    assert len(objects) == 3
+
+    objects = find_objects(protref, 'xref:Xref')
+    assert len(objects) == 3
+
+    objects = find_objects(protref, 'xref:UnificationXref')
+    assert len(objects) == 1
+    assert objects[0] == xr1
+
+    objects = find_objects(protref, 'xref:UnificationXref/xref_of')
+    assert len(objects) == 1
+    assert objects[0] == protref, objects

--- a/pybiopax/tests/test_paths.py
+++ b/pybiopax/tests/test_paths.py
@@ -6,6 +6,18 @@ def test_find_objects():
     protref = EntityReference(uid='1')
     prot = Protein(uid='2', standard_name='x', entity_reference=protref)
     protref._entity_reference_of = [prot]
+
+    # Forward reference
     objects = find_objects(prot, 'entity_reference')
     assert len(objects) == 1, objects
     assert objects[0] == protref
+
+    # Reverse reference
+    objects = find_objects(protref, 'entity_reference_of')
+    assert len(objects) == 1, objects
+    assert objects[0] == prot, objects
+
+    # Multi-step
+    objects = find_objects(prot, 'entity_reference/entity_reference_of')
+    assert len(objects) == 1, objects
+    assert objects[0] == prot, objects

--- a/pybiopax/tests/test_paths.py
+++ b/pybiopax/tests/test_paths.py
@@ -56,3 +56,21 @@ def test__with_invalid_class():
 
     with pytest.raises(BiopaxClassConstraintError):
         find_objects(xr1, 'xref_of:XXX')
+
+
+def test_recursive():
+    p1 = Protein(uid='1')
+    c1 = Complex(uid='2', member_physical_entity=[p1])
+    c2 = Complex(uid='3', member_physical_entity=[c1])
+
+    objects = find_objects(c2, 'member_physical_entity')
+    assert len(objects) == 1
+    assert objects[0] == c1
+
+    objects = find_objects(c2, 'member_physical_entity/member_physical_entity')
+    assert len(objects) == 1
+    assert objects[0] == p1
+
+    objects = find_objects(c2, 'member_physical_entity*')
+    assert len(objects) == 2, objects
+    assert set(objects) == {p1, c1}


### PR DESCRIPTION
This PR implements a function to perform a path search starting from a given `BioPaxObject` to a list of other `BioPaxObject`s given a string path specification. For example, the specification 

```
member_physical_entity*/participant_of/xref:PublicationXref
```
would find all the members of the given entity recursively, then find reactions that these members are participants of, and then return all `xref`s of type `PublicationXref` of those objects