### PR TITLE
Paper links to specific notebook version

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -97,7 +97,7 @@ corresponding to the following questions:
    of a given protein?
 
 Our implementations of these queries in the
-corresponding [Jupyter notebook](https://nbviewer.org/github/indralab/pybiopax/blob/master/notebooks/Explore%20Pathway%20Commons.ipynb)
+corresponding [Jupyter notebook](https://nbviewer.org/github/indralab/pybiopax/blob/0.1.0/notebooks/Explore%20Pathway%20Commons.ipynb)
 identified nearly 4M objects in PC12, 83 controllers that need co-factors, 1,283
 controllers that are in a phosphorylated state, 15,332 simple phosphorylation
 reactions, 13,338 proteins bound to a single small molecule, and 184 proteins
@@ -136,7 +136,7 @@ example, this highlighted a strong relationship between estradiol and GPER1,
 suggesting GPER1 activation as a mechanism of action for estradiol.
 
 The corresponding Jupyter notebook can be
-found [here](https://nbviewer.org/github/indralab/pybiopax/blob/master/notebooks/Pathway%20Anticorrelation%20Analysis.ipynb).
+found [here](https://nbviewer.org/github/indralab/pybiopax/blob/0.1.0/notebooks/Pathway%20Anticorrelation%20Analysis.ipynb).
 
 # Availability and usage
 

--- a/pybiopax/tests/test_biopax.py
+++ b/pybiopax/tests/test_biopax.py
@@ -1,4 +1,5 @@
 import os
+import re
 import pybiopax
 from pybiopax.biopax import *
 
@@ -61,7 +62,7 @@ def test_get_netpath():
 def test_get_reactome():
     m = pybiopax.model_from_reactome("177929")
     assert isinstance(m, BioPaxModel)
-    assert m.xml_base == "http://www.reactome.org/biopax/78/177929#"
+    assert re.match("http://www.reactome.org/biopax/\d+/177929#", m.xml_base)
     assert 0 < len(m.objects)
 
 


### PR DESCRIPTION
To address https://github.com/openjournals/joss-reviews/issues/4136#issuecomment-1043380706, I updated the notebook links in paper.md to use the `0.1.0` tag instead of `master`.