### PR TITLE
Use empty list by default if list-type is None

### DIFF
--- a/pybiopax/biopax/base.py
+++ b/pybiopax/biopax/base.py
@@ -1,4 +1,4 @@
-__all__ = ['BioPaxObject','Controller', 'Entity', 'Pathway', 'Gene',
+__all__ = ['BioPaxObject', 'Controller', 'Entity', 'Pathway', 'Gene',
            'Unresolved']
 
 from typing import List, Optional, TYPE_CHECKING
@@ -24,7 +24,7 @@ class BioPaxObject:
         # Pass on for cooperative inheritance
         super().__init__(**kwargs)
         self.uid = uid
-        self.comment = comment
+        self.comment = comment if comment else []
 
     @classmethod
     def from_xml(cls, element):
@@ -115,7 +115,7 @@ class XReferrable:
     def __init__(self, xref: Optional[List["Xref"]] = None, **kwargs):
         # Pass on for cooperative inheritance
         super().__init__(**kwargs)
-        self.xref = xref
+        self.xref = xref if xref else []
 
 
 class Named(XReferrable):
@@ -127,7 +127,7 @@ class Named(XReferrable):
         super().__init__(**kwargs)
         self.display_name = display_name
         self.standard_name = standard_name
-        self._name = name
+        self._name = name if name else []
 
     @property
     def name(self):
@@ -146,7 +146,7 @@ class Observable:
     def __init__(self, evidence=None, **kwargs):
         # Pass on for cooperative inheritance
         super().__init__(**kwargs)
-        self.evidence = evidence
+        self.evidence = evidence if evidence else []
 
 
 class Entity(BioPaxObject, Observable, Named):
@@ -160,7 +160,7 @@ class Entity(BioPaxObject, Observable, Named):
                  **kwargs):
         super().__init__(**kwargs)
         self.availability = availability
-        self.data_source = data_source
+        self.data_source = data_source if data_source else []
         self._participant_of = set()
 
     @property
@@ -196,7 +196,7 @@ class Pathway(Entity, Controller):
                  organism=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.pathway_component = pathway_component
+        self.pathway_component = pathway_component if pathway_component else []
         self.pathway_order = pathway_order
         self.organism = organism
 

--- a/pybiopax/biopax/interaction.py
+++ b/pybiopax/biopax/interaction.py
@@ -39,7 +39,7 @@ class Interaction(Process):
                  interaction_type=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.participant = participant
+        self.participant = participant if participant else []
         self.interaction_type = interaction_type
 
 
@@ -64,7 +64,7 @@ class TemplateReaction(Interaction):
                  **kwargs):
         super().__init__(**kwargs)
         self.template = template
-        self.product = product
+        self.product = product if product else []
         self.template_direction = template_direction
 
 
@@ -79,7 +79,7 @@ class Control(Interaction):
                  **kwargs):
         super().__init__(**kwargs)
         self.control_type = control_type
-        self.controller = controller
+        self.controller = controller if controller else []
         self.controlled = controlled
 
 
@@ -96,10 +96,11 @@ class Conversion(Interaction):
                  spontaneous=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.left = left
-        self.right = right
+        self.left = left if left else []
+        self.right = right if right else []
         self.conversion_direction = conversion_direction
-        self.participant_stoichiometry = participant_stoichiometry
+        self.participant_stoichiometry = participant_stoichiometry  if \
+            participant_stoichiometry else []
         self.spontaneous = spontaneous
 
 

--- a/pybiopax/biopax/physical_entity.py
+++ b/pybiopax/biopax/physical_entity.py
@@ -20,9 +20,10 @@ class PhysicalEntity(Entity, Controller):
                  cellular_location=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.feature = feature
-        self.not_feature = not_feature
-        self.member_physical_entity = member_physical_entity
+        self.feature = feature if feature else []
+        self.not_feature = not_feature if not_feature else []
+        self.member_physical_entity = member_physical_entity if \
+            member_physical_entity else []
         self.cellular_location = cellular_location
         self._component_of = set()
         self._member_physical_entity_of = set()
@@ -80,8 +81,9 @@ class Complex(PhysicalEntity):
                  component_stoichiometry: Optional[List] = None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.component = component
-        self.component_stoichiometry = component_stoichiometry
+        self.component = component if component else []
+        self.component_stoichiometry = component_stoichiometry if \
+            component_stoichiometry else []
 
 
 class Dna(SimplePhysicalEntity):

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -360,9 +360,10 @@ class EntityReference(UtilityClass, Named, Observable):
                  owner_entity_reference=None,
                  **kwargs):
         super().__init__(**kwargs)
-        self.entity_feature = entity_feature
+        self.entity_feature = entity_feature if entity_feature else []
         self.entity_reference_type = entity_reference_type
-        self.member_entity_reference = member_entity_reference
+        self.member_entity_reference = member_entity_reference if \
+            member_entity_reference else []
         self.owner_entity_reference = owner_entity_reference
         self._entity_reference_of = set()
         self._member_entity_reference_of = set()
@@ -473,7 +474,7 @@ class ControlledVocabulary(UtilityClass, XReferrable):
 
     def __init__(self, term: List[str] = None, **kwargs):
         super().__init__(**kwargs)
-        self.term = term
+        self.term = term if term else []
 
     def __str__(self):
         if self.term:


### PR DESCRIPTION
This PR sets list-like BioPAX object attributes to `[]` if they weren't provided during construction. Before this PR this happened automatically when parsing OWL but did not happen when an object was constructed manually. This change makes direct instantiation of BioPAX objects easier.

Relevant for #36 