### PR TITLE
Enable passing a list of BioPaxObject to BioPaxModel

### DIFF
--- a/pybiopax/biopax/model.py
+++ b/pybiopax/biopax/model.py
@@ -13,8 +13,10 @@ class BioPaxModel:
 
     Parameters
     ----------
-    objects : dict
-        A dict of BioPaxObject instances keyed by their URI string.
+    objects : dict or list
+        A dict of BioPaxObject instances keyed by their URI string or a list
+        of BioPaxObject instances, which will get converted into a dict keyed
+        their URI strings
     xml_base : str
         The XML base namespace for the content being represented.
 
@@ -28,7 +30,10 @@ class BioPaxModel:
     """
 
     def __init__(self, objects, xml_base):
-        self.objects = objects
+        if isinstance(objects, list):
+            self.objects = {o.uid: o for o in objects}
+        else:
+            self.objects = objects
         self.xml_base = xml_base
         self.add_reverse_links()
 


### PR DESCRIPTION
From the example in https://github.com/indralab/pybiopax/issues/36#issuecomment-1217788349, it seemed like it would be nicer to allow people to pass lists directly

```python
import pybiopax

from pybiopax.biopax.model import BioPaxModel
from pybiopax.biopax.base import Protein

xml_base = "http://www.biopax.org/release/biopax-level3.owl#"

objects = [
    Protein(uid="PX", display_name="LacI protein"),
]

# Before
model = BioPaxModel(objects={o.uid: o for o in objects}, xml_base=xml_base)

# After
model = BioPaxModel(objects=objects, xml_base=xml_base)