### PR TITLE
Notebook demonstrating model construction

### DIFF
--- a/notebooks/Constructing BioPAX models from scratch.ipynb
+++ b/notebooks/Constructing BioPAX models from scratch.ipynb
@@ -1,0 +1,345 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Constructing BioPAX models from scratch\n",
+    "This notebook shows how PyBioPAX can be used to create new BioPAX models as Python objects either manually or programmatically from scratch. This is different from the workflow in which a BioPAX model is obtained (deserialized) from a file or web service.\n",
+    "\n",
+    "The notebooks provides examples of the following:\n",
+    "- Creating protein and RNA physical entities\n",
+    "- Constructing protein modifications and attaching them to proteins\n",
+    "- Constructing entity references and attaching them to physical entities\n",
+    "- Creating conversions over physical entities (biochemical reaction, degradation)\n",
+    "- Representing gene expression through template reactions that produce RNA\n",
+    "- Creating controllers over conversions (e.g., regulator of a template reaction)\n",
+    "- Adding created objects to a BioPaxModel to make a model\n",
+    "- Serialize and print the completed model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pybiopax\n",
+    "from pybiopax.biopax import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a modification feature\n",
+    "A typical modification feature represents phosphorylation. The type of modification and the residue are defined using `SequenceModificationVocabulary` while the site is provided in a `SequenceSite`. Note that in PyBioPAX, simple types (str, int, float) are all represented as strings so e.g., the `sequence_position` is represented as a string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm = SequenceModificationVocabulary(uid='smf', term=['Phosphothreonine'])\n",
+    "ss = SequenceSite(uid='ss', sequence_position='202', position_status='EQUAL')\n",
+    "mf = ModificationFeature(uid='mf',\n",
+    "                         modification_type=sm,\n",
+    "                         feature_location=ss)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating physical entities and entity references\n",
+    "One example of a physical entity is a protein. Physical entities can have different features representing their state. They usually refer to an entity reference which provides absolute grounding for the base entity without a specific state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "er = ProteinReference(uid='http://identifiers.org/uniprot/P27361', display_name='MAPK3')\n",
+    "p1 = Protein(uid='p1', display_name='Erk1', entity_reference=er)\n",
+    "p2 = Protein(uid='p2', display_name='Erk1(p)', feature=[mf], entity_reference=er)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a biochemical reaction\n",
+    "A `BiochemicalReaction` can have `left` and `right` sides and various further optional attributes (here we provide a `provenance` attribute as an example)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provenance = Provenance(uid='prov', display_name='My Database')\n",
+    "br = BiochemicalReaction(uid='br',\n",
+    "                         left=[p1],\n",
+    "                         right=[p2],\n",
+    "                         data_source=provenance)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a model from objects\n",
+    "We next create a `BioPaxModel` from all the objects we have created. When constructing a model manually, we also call the `add_reverse_links` function to make sure implicit reverse links between the objects are added explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "objects = [p1, p2, er, sm, ss, mf, br, provenance]\n",
+    "model = BioPaxModel(objects=objects)\n",
+    "model.add_reverse_links()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Printing the serialized model\n",
+    "We can now serialize the model into an XML string and print it or write it to a file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b03d6af327f64252a47f0ab5ccde1b99",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Serializing OWL elements:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version='1.0' encoding='utf-8'?>\n",
+      "<rdf:RDF xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:bp=\"http://www.biopax.org/release/biopax-level3.owl#\" xml:base=\"http://www.biopax.org/release/biopax-level3.owl#\">\n",
+      "  <owl:Ontology rdf:about=\"\">\n",
+      " <owl:imports rdf:resource=\"http://www.biopax.org/release/biopax-level3.owl#\"/>\n",
+      "  </owl:Ontology>\n",
+      "\n",
+      "<bp:Protein rdf:ID=\"p1\">\n",
+      " <bp:displayName rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Erk1</bp:displayName>\n",
+      " <bp:entityReference rdf:resource=\"http://identifiers.org/uniprot/P27361\"/>\n",
+      "</bp:Protein>\n",
+      "\n",
+      "<bp:Protein rdf:ID=\"p2\">\n",
+      " <bp:displayName rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Erk1(p)</bp:displayName>\n",
+      " <bp:entityReference rdf:resource=\"http://identifiers.org/uniprot/P27361\"/>\n",
+      " <bp:feature rdf:resource=\"#mf\"/>\n",
+      "</bp:Protein>\n",
+      "\n",
+      "<bp:ProteinReference rdf:about=\"http://identifiers.org/uniprot/P27361\">\n",
+      " <bp:displayName rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">MAPK3</bp:displayName>\n",
+      "</bp:ProteinReference>\n",
+      "\n",
+      "<bp:SequenceModificationVocabulary rdf:ID=\"smf\">\n",
+      " <bp:term rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Phosphothreonine</bp:term>\n",
+      "</bp:SequenceModificationVocabulary>\n",
+      "\n",
+      "<bp:SequenceSite rdf:ID=\"ss\">\n",
+      " <bp:positionStatus rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">EQUAL</bp:positionStatus>\n",
+      " <bp:sequencePosition rdf:datatype=\"http://www.w3.org/2001/XMLSchema#int\">202</bp:sequencePosition>\n",
+      "</bp:SequenceSite>\n",
+      "\n",
+      "<bp:ModificationFeature rdf:ID=\"mf\">\n",
+      " <bp:featureLocation rdf:resource=\"#ss\"/>\n",
+      " <bp:modificationType rdf:resource=\"#smf\"/>\n",
+      "</bp:ModificationFeature>\n",
+      "\n",
+      "<bp:BiochemicalReaction rdf:ID=\"br\">\n",
+      " <bp:dataSource rdf:resource=\"#prov\"/>\n",
+      " <bp:left rdf:resource=\"#p1\"/>\n",
+      " <bp:right rdf:resource=\"#p2\"/>\n",
+      "</bp:BiochemicalReaction>\n",
+      "\n",
+      "<bp:Provenance rdf:ID=\"prov\">\n",
+      " <bp:displayName rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">My Database</bp:displayName>\n",
+      "</bp:Provenance>\n",
+      "</rdf:RDF>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "owl_str = pybiopax.model_to_owl_str(model)\n",
+    "print(owl_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Representing the regulation of gene expression\n",
+    "Here we show an example of representing the expression of a gene and its control."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18285d59619843f2a5a20077f66f02e5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Serializing OWL elements:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version='1.0' encoding='utf-8'?>\n",
+      "<rdf:RDF xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:bp=\"http://www.biopax.org/release/biopax-level3.owl#\" xml:base=\"http://www.biopax.org/release/biopax-level3.owl#\">\n",
+      "  <owl:Ontology rdf:about=\"\">\n",
+      " <owl:imports rdf:resource=\"http://www.biopax.org/release/biopax-level3.owl#\"/>\n",
+      "  </owl:Ontology>\n",
+      "\n",
+      "<bp:Protein rdf:ID=\"atf4\">\n",
+      " <bp:displayName rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">ATF4</bp:displayName>\n",
+      "</bp:Protein>\n",
+      "\n",
+      "<bp:Rna rdf:ID=\"capn6\">\n",
+      " <bp:displayName rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">CAPN6</bp:displayName>\n",
+      "</bp:Rna>\n",
+      "\n",
+      "<bp:TemplateReaction rdf:ID=\"tr\">\n",
+      " <bp:product rdf:resource=\"#capn6\"/>\n",
+      " <bp:templateDirection rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">FORWARD</bp:templateDirection>\n",
+      "</bp:TemplateReaction>\n",
+      "\n",
+      "<bp:TemplateReactionRegulation rdf:ID=\"trr\">\n",
+      " <bp:controlled rdf:resource=\"#tr\"/>\n",
+      " <bp:controller rdf:resource=\"#atf4\"/>\n",
+      "</bp:TemplateReactionRegulation>\n",
+      "</rdf:RDF>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "atf4 = Protein(uid='atf4', display_name='ATF4')\n",
+    "capn6 = Rna(uid='capn6', display_name='CAPN6')\n",
+    "tr = TemplateReaction(uid='tr',\n",
+    "                      product=[capn6],\n",
+    "                      template_direction='FORWARD')\n",
+    "trr = TemplateReactionRegulation(uid='trr',\n",
+    "                                 controller=[atf4],\n",
+    "                                 controlled=tr)\n",
+    "model = BioPaxModel([atf4, capn6, tr, trr])\n",
+    "print(pybiopax.model_to_owl_str(model))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Representing degradation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c6b90f3420fe4070a9187444036a1ca0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Serializing OWL elements:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version='1.0' encoding='utf-8'?>\n",
+      "<rdf:RDF xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:bp=\"http://www.biopax.org/release/biopax-level3.owl#\" xml:base=\"http://www.biopax.org/release/biopax-level3.owl#\">\n",
+      "  <owl:Ontology rdf:about=\"\">\n",
+      " <owl:imports rdf:resource=\"http://www.biopax.org/release/biopax-level3.owl#\"/>\n",
+      "  </owl:Ontology>\n",
+      "\n",
+      "<bp:Protein rdf:ID=\"mdm2\">\n",
+      " <bp:displayName rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">MDM2</bp:displayName>\n",
+      "</bp:Protein>\n",
+      "\n",
+      "<bp:Degradation rdf:ID=\"deg\">\n",
+      " <bp:left rdf:resource=\"#mdm2\"/>\n",
+      "</bp:Degradation>\n",
+      "</rdf:RDF>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pr = Protein(uid='mdm2', display_name='MDM2')\n",
+    "deg = Degradation(uid='deg', left=[pr], right=[])\n",
+    "model = BioPaxModel([pr, deg])\n",
+    "print(pybiopax.model_to_owl_str(model))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/Constructing BioPAX models from scratch.ipynb
+++ b/notebooks/Constructing BioPAX models from scratch.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "source": [
     "## Creating a model from objects\n",
-    "We next create a `BioPaxModel` from all the objects we have created. When constructing a model manually, we also call the `add_reverse_links` function to make sure implicit reverse links between the objects are added explicitly."
+    "We next create a `BioPaxModel` from all the objects we have created. When constructing a model manually, we also call the `add_reverse_links` function to make sure implicit reverse links between the objects are added explicitly. These reverse links only exist in memory and help in certain model traversal tasks."
    ]
   },
   {
@@ -113,7 +113,7 @@
    "metadata": {},
    "source": [
     "## Printing the serialized model\n",
-    "We can now serialize the model into an XML string and print it or write it to a file."
+    "We can now serialize the model into an XML string and print it or write it to a file. Note that the reverse links never appear in serialized form, they only exist in memory where they can be used for complex model traversal."
    ]
   },
   {
@@ -124,7 +124,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b03d6af327f64252a47f0ab5ccde1b99",
+       "model_id": "77c00b5b96f045ee9ef9ff2adcffe3ce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -209,7 +209,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18285d59619843f2a5a20077f66f02e5",
+       "model_id": "58eeb66f29f244b195071dac9b6ae4ed",
        "version_major": 2,
        "version_minor": 0
       },
@@ -280,7 +280,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6b90f3420fe4070a9187444036a1ca0",
+       "model_id": "e7ab23c27a4b4e7b9c0653a6fbf7bd59",
        "version_major": 2,
        "version_minor": 0
       },

--- a/notebooks/Constructing BioPAX models from scratch.ipynb
+++ b/notebooks/Constructing BioPAX models from scratch.ipynb
@@ -15,7 +15,13 @@
     "- Representing gene expression through template reactions that produce RNA\n",
     "- Creating controllers over conversions (e.g., regulator of a template reaction)\n",
     "- Adding created objects to a BioPaxModel to make a model\n",
-    "- Serialize and print the completed model"
+    "- Serialize and print the completed model\n",
+    "\n",
+    "You can learn more about the BioPAX specification and the semantics of various parts of it here:\n",
+    "- The BioPAX Level 3 specification: http://www.biopax.org/release/biopax-level3-documentation.pdf\n",
+    "- The BioPAX OWL docs: http://www.biopax.org/owldoc/Level3/\n",
+    "\n",
+    "Note that in the PyBioPAX implementation, all class parameters and attributes use the Python convention for capitalization, so e.g., the `sequencePosition` attribute in the BioPAX specification is capitalized as `sequence_position` in PyBioPAX. Of course, this just affects the in-memory representation of BioPAX objects, and does not affect the serialized BioPAX XML PyBioPAX reads and writes."
    ]
   },
   {

--- a/pybiopax/biopax/model.py
+++ b/pybiopax/biopax/model.py
@@ -7,6 +7,8 @@ from tqdm.auto import tqdm
 from . import *
 from ..xml_util import get_id_or_about, get_tag, has_ns, wrap_xml_elements
 
+default_xml_base = 'http://www.biopax.org/release/biopax-level3.owl#'
+
 
 class BioPaxModel:
     """BioPAX Model.
@@ -25,11 +27,12 @@ class BioPaxModel:
     objects : dict
         A dict of BioPaxObject instances keyed by their URI string
         that are part of the model.
-    xml_base : str
-        The XML base namespace for the content being represented.
+    xml_base : Optional[str]
+        The XML base namespace for the content being represented. If not
+        provided, the default BioPAX Level 3 base namespace is used.
     """
 
-    def __init__(self, objects, xml_base):
+    def __init__(self, objects, xml_base=default_xml_base):
         if isinstance(objects, list):
             self.objects = {o.uid: o for o in objects}
         else:


### PR DESCRIPTION
This PR adds a notebook demonstrating how some BioPAX models can be constructed as Python objects from scratch (i.e., not coming from an existing file or web service). It also adds a default value for the `xml_base` of a `BioPaxModel` so it doesn't have to be manually added when making models from scratch.

Resolves #36.