### PR TITLE
Add attributes to NucleicAcid reference BioPAX classes

### DIFF
--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -534,9 +534,22 @@ class NucleicAcidReference(SequenceEntityReference):
 
 
 class NucleicAcidRegionReference(NucleicAcidReference):
-    """BioPAX NucleicAcidRegionReference"""
-    def __init__(self, **kwargs):
+    """BioPAX NucleicAcidRegionReference
+
+    Attributes
+    ----------
+    absolute_region : SequenceLocation
+    region_type : List[SequenceRegionVocabulary]
+    """
+    list_types = NucleicAcidReference.list_types + ['region_type']
+
+    def __init__(self,
+                 absolute_region=None,
+                 region_type=None,
+                 **kwargs):
         super().__init__(**kwargs)
+        self.absolute_region = absolute_region
+        self.region_type = region_type if region_type else []
         self._subregion_of = set()
 
     @property

--- a/pybiopax/biopax/util.py
+++ b/pybiopax/biopax/util.py
@@ -529,8 +529,19 @@ class SequenceEntityReference(EntityReference):
 
 
 class NucleicAcidReference(SequenceEntityReference):
-    """BioPAX NucleicAcidReference"""
-    pass
+    """BioPAX NucleicAcidReference
+
+    Attributes
+    ----------
+    sub_region : List[NucleicAcidRegionReference]
+    """
+    list_types = SequenceEntityReference.list_types + ['sub_region']
+
+    def __init__(self,
+                 sub_region=None,
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.sub_region = sub_region if sub_region else []
 
 
 class NucleicAcidRegionReference(NucleicAcidReference):
@@ -550,11 +561,11 @@ class NucleicAcidRegionReference(NucleicAcidReference):
         super().__init__(**kwargs)
         self.absolute_region = absolute_region
         self.region_type = region_type if region_type else []
-        self._subregion_of = set()
+        self._sub_region_of = set()
 
     @property
-    def subregion_of(self):
-        return self._subregion_of
+    def sub_region_of(self):
+        return self._sub_region_of
 
 
 class RnaReference(NucleicAcidReference):


### PR DESCRIPTION
Fixes #47. This PR adds some missing attributes to NucleicAcidReference and NucleicAcidRegionReference to match the BioPAX reference implementation.